### PR TITLE
Dialog show fix

### DIFF
--- a/Nez-PCL/UI/Widgets/Dialog.cs
+++ b/Nez-PCL/UI/Widgets/Dialog.cs
@@ -95,10 +95,10 @@ namespace Nez.UI
 		/// <param name="stage">Stage.</param>
 		public Dialog show( Stage stage )
 		{
+			stage.addElement( this );
 			setPosition( Mathf.round( ( stage.getWidth() - getWidth() ) / 2 ), Mathf.round( ( stage.getHeight() - getHeight() ) / 2 ) );
 
 			pack();
-			stage.addElement( this );
 
 			return this;
 		}


### PR DESCRIPTION
Dialog.show will throw a NullReferenceException when it gets to Window.keepWithinStage - it goes there because it gets moved to the center of the stage, but at that point there's no stage for keepWithinStage to use.
